### PR TITLE
Add backend requirements file and README update

### DIFF
--- a/Housing_AI/requirements.txt
+++ b/Housing_AI/requirements.txt
@@ -1,0 +1,9 @@
+Django
+djangorestframework
+djangorestframework-simplejwt
+django-cors-headers
+drf-yasg
+django-allauth
+requests
+itsdangerous
+Pillow

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ce projet regroupe un backend Django pour la logique serveur et un frontend Reac
 cd Housing_AI
 python -m venv venv
 source venv/bin/activate
-pip install django djangorestframework drf-yasg djangorestframework-simplejwt corsheaders
+pip install -r requirements.txt
 python manage.py migrate
 python manage.py runserver
 ```


### PR DESCRIPTION
## Summary
- list backend Python packages in `Housing_AI/requirements.txt`
- update backend setup instructions in README to use this file

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6865c808737c8329b11b2e941086d74d