### PR TITLE
Refactor axios requests

### DIFF
--- a/housing-ai/src/pages/ListeAnnonces.jsx
+++ b/housing-ai/src/pages/ListeAnnonces.jsx
@@ -1,22 +1,27 @@
 import React, { useEffect, useState } from 'react'
-import axios from 'axios'
+import axios from '../axios'
 import LogementCard from '../components/LogementCard'
 
 const ListeAnnonces = () => {
   const [annonces, setAnnonces] = useState([])
+  const [error, setError] = useState('')
 
   useEffect(() => {
-    axios.get('http://localhost:8000/api/annonces/')
-      .then((res) =>{
-
-      console.log("✅ Annonces :", res.data)
-      setAnnonces(res.data)
-      })
-      .catch(err => console.error("Erreur API :", err))
+    const fetchAnnonces = async () => {
+      try {
+        const res = await axios.get('annonces/')
+        setAnnonces(res.data)
+      } catch (err) {
+        const msg = err.response?.data?.error || 'Erreur lors de la récupération des annonces.'
+        setError(msg)
+      }
+    }
+    fetchAnnonces()
   }, [])
 
   return (
     <div className="min-h-screen bg-gray-50 py-10 px-4">
+        {error && <div className="text-red-600 mb-4">{error}</div>}
         <div className="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {annonces.map(annonce => (
           <LogementCard

--- a/housing-ai/src/pages/register.jsx
+++ b/housing-ai/src/pages/register.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import axios from 'axios'
+import axios from '../axios'
 
 const Register = () => {
   const [email, setEmail] = useState('')
@@ -13,32 +13,25 @@ const Register = () => {
   setError('')
 
   try {
-    const response = await axios({
-      method: 'post',
-      url: 'http://localhost:8000/api/register/',
-      data: {
-        email,
-        password
-      },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    })
-    console.log("✅ Réponse :", response)
+    const response = await axios.post(
+      'register/',
+      { email, password },
+      { headers: { 'Content-Type': 'application/json' } }
+    )
     setMessage(response.data.message || 'Inscription réussie.')
     setEmail('')
     setPassword('')
   } catch (err) {
-  console.error("Erreur API :", err.response?.data)
+    let errorMsg = "Erreur lors de l'inscription."
 
-  if (err.response?.data?.password) {
-    setError(err.response.data.password.join(' '))
-  } else if (err.response?.data?.error) {
-    setError(err.response.data.error)
-  } else {
-    setError("Erreur lors de l'inscription.")
+    if (err.response?.data?.password) {
+      errorMsg = err.response.data.password.join(' ')
+    } else if (err.response?.data?.error) {
+      errorMsg = err.response.data.error
+    }
+
+    setError(errorMsg)
   }
-}
 }
 
   return (


### PR DESCRIPTION
## Summary
- use a centralized axios instance across pages
- wrap API requests in try/catch with clearer errors
- remove leftover console logging

## Testing
- `npm run lint`
- `python manage.py test` *(fails: `ImportError: No module named 'django'`)*

------
https://chatgpt.com/codex/tasks/task_e_6865c860cea08329815c707a823a05f6