### PR TITLE
Use env variable for API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ cd housing-ai
 npm install
 npm run dev
 ```
+
+## Configuration
+
+Le frontend utilise la variable d'environnement `VITE_API_URL` pour savoir
+où joindre l'API. Un fichier `.env.example` est disponible dans `housing-ai/`
+avec la valeur par défaut :
+
+```bash
+VITE_API_URL=http://localhost:8000/api/
+```
+
+Copiez ce fichier en `.env` et ajustez l'URL selon votre environnement.

--- a/housing-ai/.env.example
+++ b/housing-ai/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000/api/

--- a/housing-ai/src/axios.js
+++ b/housing-ai/src/axios.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
 export default axios.create({
-  baseURL: "http://localhost:8000/api/",
-  withCredentials: false,  // True si tu utilises l’authentification par cookie
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: false, // True si tu utilises l’authentification par cookie
 });


### PR DESCRIPTION
## Summary
- configure Axios to use `import.meta.env.VITE_API_URL`
- document `VITE_API_URL` usage in README
- add `.env.example` file

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6865cc32143883298e58e4d19ac9a00a