### PR TITLE
Add AuthContext for authentication

### DIFF
--- a/housing-ai/src/context/AuthContext.jsx
+++ b/housing-ai/src/context/AuthContext.jsx
@@ -1,0 +1,50 @@
+import { createContext, useState, useEffect, useCallback } from 'react'
+import axios from '../axios'
+
+/* eslint-disable react-refresh/only-export-components */
+
+export const AuthContext = createContext()
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('token'))
+  const [user, setUser] = useState(null)
+
+  const loadProfile = useCallback(async (tkn = token) => {
+    if (!tkn) return
+    try {
+      const res = await axios.get('profile/', {
+        headers: { Authorization: `Bearer ${tkn}` },
+      })
+      setUser(res.data)
+    } catch {
+      setUser(null)
+    }
+  }, [token])
+
+  useEffect(() => {
+    if (token) {
+      loadProfile(token)
+    }
+  }, [token, loadProfile])
+
+  const login = async (email, password) => {
+    const res = await axios.post('token/', { email, password })
+    const accessToken = res.data.access
+    setToken(accessToken)
+    localStorage.setItem('token', accessToken)
+    await loadProfile(accessToken)
+  }
+
+
+  const logout = () => {
+    setToken(null)
+    setUser(null)
+    localStorage.removeItem('token')
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/housing-ai/src/main.jsx
+++ b/housing-ai/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { AuthProvider } from './context/AuthContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- create `AuthContext` with login, logout and profile loading
- wrap application with the new provider

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865cbc5a5188329bd3e1316e1f6971f