### PR TITLE
Fix duplicate route

### DIFF
--- a/housing-ai/src/App.jsx
+++ b/housing-ai/src/App.jsx
@@ -22,7 +22,6 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
             <Route path="/profile" element={<Profile />} />
-            <Route path="/login" element={<Login />} />
           </Routes>
         </main>
 


### PR DESCRIPTION
## Summary
- remove duplicate `/login` route from `App.jsx`

## Testing
- `python manage.py test`
- `npm run lint` *(fails: Identifier 'AuthProvider' has already been declared)*
- `npm run build` *(fails: The symbol "AuthProvider" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6865f85e7d10832989136fcc0353187d